### PR TITLE
Verify reposado branches

### DIFF
--- a/repotoddylib/repotoddycommon.py
+++ b/repotoddylib/repotoddycommon.py
@@ -120,6 +120,12 @@ def diff_branches(branch_list):
 
 def arrange_branches(branch_list):
     '''user interaction to arrange branches in preferred order'''
+
+    if not branch_list:
+      print('WARNING: Please setup reposado with at least two branches '
+            'to use repotoddy...')
+      sys.exit(1)
+
     arranged_branches = []
     branch_num = 0
     while len(branch_list) > 0:


### PR DESCRIPTION
When configuring, the script should exit if no reposado branches are created. 


Tested by deleting all reposado branches and running script. output:
```
$ ./repotoddy --configure
Arrange Reposado Branches for automation.
To arrange. (y)
Use existing. (Enter)
Exit. (Ctrl-C)
Current Config: []: y
WARNING: Please setup reposado with at least two branches to use repotoddy...
```