### PR TITLE
Additional flag to specify preference file

### DIFF
--- a/repotoddy
+++ b/repotoddy
@@ -253,7 +253,8 @@ def main():
 
     p.add_option('--configure', '-c', action='store_true',
                  help='Configure repotoddy for use.')
-
+    p.add_option('--pref_file', '-p', dest='pref_file',
+                 help='Preference file to use.')
     p.add_option('--munki', '-m', action='store_true', default=False,
                  help='Downloads latest Apple Updates, and imports new items '
                  'that require a restart into munki. Works with "--run" or'
@@ -278,6 +279,13 @@ def main():
 
     options, arguments = p.parse_args()
 
+
+    if options.pref_file:
+      if options.configure or os.path.exists(options.pref_file):
+        repotoddycommon.PREF_PATH = options.pref_file
+      else:
+        print('Preference file does not exists')
+        exit()
     if options.configure:
         repotoddycommon.configure_prefs()
     sync_changes = options.no_sync

--- a/repotoddylib/repotoddycommon.py
+++ b/repotoddylib/repotoddycommon.py
@@ -32,6 +32,8 @@ import os
 import plistlib
 import datetime
 
+PREF_PATH = None
+
 
 def configure_prefs():
     """Configures prefs for use"""
@@ -64,7 +66,7 @@ def configure_prefs():
         except AttributeError:
             pass
         _prefs[key] = newvalue or pref(key) or ''
-    toddy_plist = os.path.join(get_main_dir(), 'repotoddy_prefs.plist')
+    toddy_plist = pref_file()
     try:
         old_prefs = plistlib.readPlist(toddy_plist)
     except IOError as e:
@@ -90,9 +92,17 @@ def get_main_dir():
     return os.path.dirname(sys.argv[0])
 
 
+def pref_file():
+  ''' Returns preference file '''
+  if PREF_PATH:
+    return os.path.abspath(PREF_PATH)
+
+  return os.path.join(get_main_dir(), 'repotoddy_prefs.plist')
+
+
 def pref(key):
     '''Returns the value of preference key'''
-    toddy_plist = os.path.join(get_main_dir(), 'repotoddy_prefs.plist')
+    toddy_plist = pref_file()
     try:
         prefs = plistlib.readPlist(toddy_plist)
     except IOError:


### PR DESCRIPTION
We have a need to update branches at different time intervals. For example, we want updates to sit in testing for 24 hours then shard out hourly. With the option to set a preference files,  we can accomplish this.  

Cron would look like
```
* 8 * * *  repotoddy --run -p repotoddy_pref_daily.plist
0 * * * *  repotoddy --run -p repotoddy_pref_hourly.plist
```

# Testing

configure flag set and test.plist doesn't exist
```
$ ./repotoddy --run --configure -p test.plist
Arrange Reposado Branches for automation.
To arrange. (y)
Use existing. (Enter)
Exit. (Ctrl-C)
Current Config: []

cat test.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
```
pref file flag set and pref file doesn't exist 
```
$ ./repotoddy --run -p test1.plist
Preference file does not exists
```

pref file flag set and pref file exists 
```
./repotoddy --run -p repotoddy_prefs_dailyrun.plist
Comparing shard2, to shard3...
Found no changes...
Comparing shard1, to shard2...
```

normal run 
```
$ ./repotoddy --run
Comparing shard3, to shard4...
Found no changes...
Comparing shard2, to shard3...
Found no changes...
```


