### PR TITLE
Setting force install description preference

### DIFF
--- a/repotoddy
+++ b/repotoddy
@@ -142,6 +142,8 @@ def generate_pkginfo(munki_dir, items, force):
         if force:
             force_time = repotoddycommon.get_force_install()
             pkginfo_template['force_install_after_date'] = force_time
+            force_description = repotoddycommon.pref('MunkiForceDescription')
+            pkginfo_template['description'] = force_description
         pkginfo_template['display_name'] = all_products[item]['title']
         dis_name = pkginfo_template['display_name']
         ver = pkginfo_template['version']

--- a/repotoddylib/repotoddycommon.py
+++ b/repotoddylib/repotoddycommon.py
@@ -150,6 +150,7 @@ def get_munki_apple_update_template():
     pkginfo_template = {
         'catalogs': [''],
         'display_name': '',
+        'description': '',
         'force_install_after_date': '',
         'installer_type': 'apple_update_metadata',
         'name': '',


### PR DESCRIPTION
This will give the option to set a default description for munki apple meta pkginfo files. 

To test, I added the value to repotoddy_prefs.plist, ran repotoddy -a -f, and checked a pkginfo file

```
 cat zzz091-9767-Security_Update_2013-004-1.0.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>catalogs</key>
	<array>
		<string>all</string>
	</array>
	<key>description</key>
	<string>this is a test
123
245
    </string>
	<key>display_name</key>
	<string>Security Update 2013-004</string>
	<key>force_install_after_date</key>
	<date>2017-10-08T13:00:00Z</date>
	<key>installer_type</key>
	<string>apple_update_metadata</string>
	<key>name</key>
	<string>zzz091-9767</string>
	<key>version</key>
	<string>1.0</string>
</dict>
</plist>
```